### PR TITLE
Remove storage_usage attribute

### DIFF
--- a/docs/data-sources/mailbox.md
+++ b/docs/data-sources/mailbox.md
@@ -67,6 +67,5 @@ data "migadu_mailbox" "idn" {
 - `sender_denylist_punycode` (List of String) The email addresses of senders that will always be denied delivery in punycode.
 - `spam_action` (String) The action to take once spam arrives in the mailbox.
 - `spam_aggressiveness` (String) How aggressive will spam be detected in the mailbox.
-- `storage_usage` (Number) The current storage usage of the mailbox.
 
 

--- a/docs/data-sources/mailboxes.md
+++ b/docs/data-sources/mailboxes.md
@@ -73,6 +73,5 @@ Read-Only:
 - `sender_denylist_punycode` (List of String) The email addresses of senders that will always be denied delivery in punycode.
 - `spam_action` (String) The action to take once spam arrives in this mailbox.
 - `spam_aggressiveness` (String) How aggressive will spam be detected in this mailbox.
-- `storage_usage` (Number) The current storage usage of this mailbox.
 
 

--- a/docs/resources/mailbox.md
+++ b/docs/resources/mailbox.md
@@ -76,7 +76,6 @@ resource "migadu_mailbox" "idn" {
 
 - `address` (String) The email address of the mailbox `local_part@domain_name` as returned by the Migadu API. This might be different from the `id` attribute in case you are using international domain names. The Migadu API always returns the punycode version of a domain.
 - `id` (String) Contains the value `local_part@domain_name`.
-- `storage_usage` (Number) The current storage usage of this mailbox.
 
 ## Import
 

--- a/internal/provider/mailbox_data_source.go
+++ b/internal/provider/mailbox_data_source.go
@@ -30,41 +30,40 @@ type mailboxDataSource struct {
 }
 
 type mailboxDataSourceModel struct {
-	ID                        types.String  `tfsdk:"id"`
-	LocalPart                 types.String  `tfsdk:"local_part"`
-	DomainName                types.String  `tfsdk:"domain_name"`
-	Address                   types.String  `tfsdk:"address"`
-	Name                      types.String  `tfsdk:"name"`
-	IsInternal                types.Bool    `tfsdk:"is_internal"`
-	MaySend                   types.Bool    `tfsdk:"may_send"`
-	MayReceive                types.Bool    `tfsdk:"may_receive"`
-	MayAccessImap             types.Bool    `tfsdk:"may_access_imap"`
-	MayAccessPop3             types.Bool    `tfsdk:"may_access_pop3"`
-	MayAccessManageSieve      types.Bool    `tfsdk:"may_access_manage_sieve"`
-	PasswordRecoveryEmail     types.String  `tfsdk:"password_recovery_email"`
-	SpamAction                types.String  `tfsdk:"spam_action"`
-	SpamAggressiveness        types.String  `tfsdk:"spam_aggressiveness"`
-	Expirable                 types.Bool    `tfsdk:"expirable"`
-	ExpiresOn                 types.String  `tfsdk:"expires_on"`
-	RemoveUponExpiry          types.Bool    `tfsdk:"remove_upon_expiry"`
-	SenderDenyList            types.List    `tfsdk:"sender_denylist"`
-	SenderDenyListPunycode    types.List    `tfsdk:"sender_denylist_punycode"`
-	SenderAllowList           types.List    `tfsdk:"sender_allowlist"`
-	SenderAllowListPunycode   types.List    `tfsdk:"sender_allowlist_punycode"`
-	RecipientDenyList         types.List    `tfsdk:"recipient_denylist"`
-	RecipientDenyListPunycode types.List    `tfsdk:"recipient_denylist_punycode"`
-	AutoRespondActive         types.Bool    `tfsdk:"auto_respond_active"`
-	AutoRespondSubject        types.String  `tfsdk:"auto_respond_subject"`
-	AutoRespondBody           types.String  `tfsdk:"auto_respond_body"`
-	AutoRespondExpiresOn      types.String  `tfsdk:"auto_respond_expires_on"`
-	FooterActive              types.Bool    `tfsdk:"footer_active"`
-	FooterPlainBody           types.String  `tfsdk:"footer_plain_body"`
-	FooterHtmlBody            types.String  `tfsdk:"footer_html_body"`
-	StorageUsage              types.Float64 `tfsdk:"storage_usage"`
-	Delegations               types.List    `tfsdk:"delegations"`
-	DelegationsPunycode       types.List    `tfsdk:"delegations_punycode"`
-	Identities                types.List    `tfsdk:"identities"`
-	IdentitiesPunycode        types.List    `tfsdk:"identities_punycode"`
+	ID                        types.String `tfsdk:"id"`
+	LocalPart                 types.String `tfsdk:"local_part"`
+	DomainName                types.String `tfsdk:"domain_name"`
+	Address                   types.String `tfsdk:"address"`
+	Name                      types.String `tfsdk:"name"`
+	IsInternal                types.Bool   `tfsdk:"is_internal"`
+	MaySend                   types.Bool   `tfsdk:"may_send"`
+	MayReceive                types.Bool   `tfsdk:"may_receive"`
+	MayAccessImap             types.Bool   `tfsdk:"may_access_imap"`
+	MayAccessPop3             types.Bool   `tfsdk:"may_access_pop3"`
+	MayAccessManageSieve      types.Bool   `tfsdk:"may_access_manage_sieve"`
+	PasswordRecoveryEmail     types.String `tfsdk:"password_recovery_email"`
+	SpamAction                types.String `tfsdk:"spam_action"`
+	SpamAggressiveness        types.String `tfsdk:"spam_aggressiveness"`
+	Expirable                 types.Bool   `tfsdk:"expirable"`
+	ExpiresOn                 types.String `tfsdk:"expires_on"`
+	RemoveUponExpiry          types.Bool   `tfsdk:"remove_upon_expiry"`
+	SenderDenyList            types.List   `tfsdk:"sender_denylist"`
+	SenderDenyListPunycode    types.List   `tfsdk:"sender_denylist_punycode"`
+	SenderAllowList           types.List   `tfsdk:"sender_allowlist"`
+	SenderAllowListPunycode   types.List   `tfsdk:"sender_allowlist_punycode"`
+	RecipientDenyList         types.List   `tfsdk:"recipient_denylist"`
+	RecipientDenyListPunycode types.List   `tfsdk:"recipient_denylist_punycode"`
+	AutoRespondActive         types.Bool   `tfsdk:"auto_respond_active"`
+	AutoRespondSubject        types.String `tfsdk:"auto_respond_subject"`
+	AutoRespondBody           types.String `tfsdk:"auto_respond_body"`
+	AutoRespondExpiresOn      types.String `tfsdk:"auto_respond_expires_on"`
+	FooterActive              types.Bool   `tfsdk:"footer_active"`
+	FooterPlainBody           types.String `tfsdk:"footer_plain_body"`
+	FooterHtmlBody            types.String `tfsdk:"footer_html_body"`
+	Delegations               types.List   `tfsdk:"delegations"`
+	DelegationsPunycode       types.List   `tfsdk:"delegations_punycode"`
+	Identities                types.List   `tfsdk:"identities"`
+	IdentitiesPunycode        types.List   `tfsdk:"identities_punycode"`
 }
 
 func (d *mailboxDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
@@ -238,11 +237,6 @@ func (d *mailboxDataSource) Schema(_ context.Context, _ datasource.SchemaRequest
 				MarkdownDescription: "The footer of the mailbox in `text/html` format.",
 				Computed:            true,
 			},
-			"storage_usage": schema.Float64Attribute{
-				Description:         "The current storage usage of the mailbox.",
-				MarkdownDescription: "The current storage usage of the mailbox.",
-				Computed:            true,
-			},
 			"delegations": schema.ListAttribute{
 				Description:         "The delegations of the mailbox in unicode.",
 				MarkdownDescription: "The delegations of the mailbox in unicode.",
@@ -350,7 +344,6 @@ func (d *mailboxDataSource) Read(ctx context.Context, req datasource.ReadRequest
 	data.FooterActive = types.BoolValue(mailbox.FooterActive)
 	data.FooterPlainBody = types.StringValue(mailbox.FooterPlainBody)
 	data.FooterHtmlBody = types.StringValue(mailbox.FooterHtmlBody)
-	data.StorageUsage = types.Float64Value(mailbox.StorageUsage)
 	data.SenderDenyList = senderDenyList
 	data.SenderDenyListPunycode = senderDenyListPunycode
 	data.SenderAllowList = senderAllowList

--- a/internal/provider/mailbox_resource.go
+++ b/internal/provider/mailbox_resource.go
@@ -12,7 +12,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/float64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -50,27 +49,26 @@ type mailboxResourceModel struct {
 	MayAccessPop3        types.Bool   `tfsdk:"may_access_pop3"`
 	MayAccessManageSieve types.Bool   `tfsdk:"may_access_manage_sieve"`
 	//PasswordMethod            types.String  `tfsdk:"password_method"`
-	Password                  types.String  `tfsdk:"password"`
-	PasswordRecoveryEmail     types.String  `tfsdk:"password_recovery_email"`
-	SpamAction                types.String  `tfsdk:"spam_action"`
-	SpamAggressiveness        types.String  `tfsdk:"spam_aggressiveness"`
-	Expirable                 types.Bool    `tfsdk:"expirable"`
-	ExpiresOn                 types.String  `tfsdk:"expires_on"`
-	RemoveUponExpiry          types.Bool    `tfsdk:"remove_upon_expiry"`
-	SenderDenyList            types.List    `tfsdk:"sender_denylist"`
-	SenderDenyListPunycode    types.List    `tfsdk:"sender_denylist_punycode"`
-	SenderAllowList           types.List    `tfsdk:"sender_allowlist"`
-	SenderAllowListPunycode   types.List    `tfsdk:"sender_allowlist_punycode"`
-	RecipientDenyList         types.List    `tfsdk:"recipient_denylist"`
-	RecipientDenyListPunycode types.List    `tfsdk:"recipient_denylist_punycode"`
-	AutoRespondActive         types.Bool    `tfsdk:"auto_respond_active"`
-	AutoRespondSubject        types.String  `tfsdk:"auto_respond_subject"`
-	AutoRespondBody           types.String  `tfsdk:"auto_respond_body"`
-	AutoRespondExpiresOn      types.String  `tfsdk:"auto_respond_expires_on"`
-	FooterActive              types.Bool    `tfsdk:"footer_active"`
-	FooterPlainBody           types.String  `tfsdk:"footer_plain_body"`
-	FooterHtmlBody            types.String  `tfsdk:"footer_html_body"`
-	StorageUsage              types.Float64 `tfsdk:"storage_usage"`
+	Password                  types.String `tfsdk:"password"`
+	PasswordRecoveryEmail     types.String `tfsdk:"password_recovery_email"`
+	SpamAction                types.String `tfsdk:"spam_action"`
+	SpamAggressiveness        types.String `tfsdk:"spam_aggressiveness"`
+	Expirable                 types.Bool   `tfsdk:"expirable"`
+	ExpiresOn                 types.String `tfsdk:"expires_on"`
+	RemoveUponExpiry          types.Bool   `tfsdk:"remove_upon_expiry"`
+	SenderDenyList            types.List   `tfsdk:"sender_denylist"`
+	SenderDenyListPunycode    types.List   `tfsdk:"sender_denylist_punycode"`
+	SenderAllowList           types.List   `tfsdk:"sender_allowlist"`
+	SenderAllowListPunycode   types.List   `tfsdk:"sender_allowlist_punycode"`
+	RecipientDenyList         types.List   `tfsdk:"recipient_denylist"`
+	RecipientDenyListPunycode types.List   `tfsdk:"recipient_denylist_punycode"`
+	AutoRespondActive         types.Bool   `tfsdk:"auto_respond_active"`
+	AutoRespondSubject        types.String `tfsdk:"auto_respond_subject"`
+	AutoRespondBody           types.String `tfsdk:"auto_respond_body"`
+	AutoRespondExpiresOn      types.String `tfsdk:"auto_respond_expires_on"`
+	FooterActive              types.Bool   `tfsdk:"footer_active"`
+	FooterPlainBody           types.String `tfsdk:"footer_plain_body"`
+	FooterHtmlBody            types.String `tfsdk:"footer_html_body"`
 }
 
 func (r *mailboxResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -307,14 +305,6 @@ func (r *mailboxResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 				Optional:            true,
 				Computed:            true,
 			},
-			"storage_usage": schema.Float64Attribute{
-				Description:         "The current storage usage of this mailbox.",
-				MarkdownDescription: "The current storage usage of this mailbox.",
-				Computed:            true,
-				PlanModifiers: []planmodifier.Float64{
-					float64planmodifier.UseStateForUnknown(),
-				},
-			},
 		},
 	}
 }
@@ -472,7 +462,6 @@ func (r *mailboxResource) Create(ctx context.Context, req resource.CreateRequest
 	plan.FooterActive = types.BoolValue(createdMailbox.FooterActive)
 	plan.FooterPlainBody = types.StringValue(createdMailbox.FooterPlainBody)
 	plan.FooterHtmlBody = types.StringValue(createdMailbox.FooterHtmlBody)
-	plan.StorageUsage = types.Float64Value(createdMailbox.StorageUsage)
 
 	diags = resp.State.Set(ctx, plan)
 	resp.Diagnostics.Append(diags...)
@@ -542,7 +531,6 @@ func (r *mailboxResource) Read(ctx context.Context, req resource.ReadRequest, re
 	state.FooterActive = types.BoolValue(mailbox.FooterActive)
 	state.FooterPlainBody = types.StringValue(mailbox.FooterPlainBody)
 	state.FooterHtmlBody = types.StringValue(mailbox.FooterHtmlBody)
-	state.StorageUsage = types.Float64Value(mailbox.StorageUsage)
 
 	diags = resp.State.Set(ctx, &state)
 	resp.Diagnostics.Append(diags...)
@@ -686,7 +674,6 @@ func (r *mailboxResource) Update(ctx context.Context, req resource.UpdateRequest
 	plan.FooterActive = types.BoolValue(updatedMailbox.FooterActive)
 	plan.FooterPlainBody = types.StringValue(updatedMailbox.FooterPlainBody)
 	plan.FooterHtmlBody = types.StringValue(updatedMailbox.FooterHtmlBody)
-	plan.StorageUsage = types.Float64Value(updatedMailbox.StorageUsage)
 
 	diags = resp.State.Set(ctx, plan)
 	resp.Diagnostics.Append(diags...)

--- a/internal/provider/mailboxes_data_source.go
+++ b/internal/provider/mailboxes_data_source.go
@@ -36,40 +36,39 @@ type mailboxesDataSourceModel struct {
 }
 
 type mailboxModel struct {
-	LocalPart                 types.String  `tfsdk:"local_part"`
-	DomainName                types.String  `tfsdk:"domain_name"`
-	Address                   types.String  `tfsdk:"address"`
-	Name                      types.String  `tfsdk:"name"`
-	IsInternal                types.Bool    `tfsdk:"is_internal"`
-	MaySend                   types.Bool    `tfsdk:"may_send"`
-	MayReceive                types.Bool    `tfsdk:"may_receive"`
-	MayAccessImap             types.Bool    `tfsdk:"may_access_imap"`
-	MayAccessPop3             types.Bool    `tfsdk:"may_access_pop3"`
-	MayAccessManageSieve      types.Bool    `tfsdk:"may_access_manage_sieve"`
-	PasswordRecoveryEmail     types.String  `tfsdk:"password_recovery_email"`
-	SpamAction                types.String  `tfsdk:"spam_action"`
-	SpamAggressiveness        types.String  `tfsdk:"spam_aggressiveness"`
-	Expirable                 types.Bool    `tfsdk:"expirable"`
-	ExpiresOn                 types.String  `tfsdk:"expires_on"`
-	RemoveUponExpiry          types.Bool    `tfsdk:"remove_upon_expiry"`
-	SenderDenyList            types.List    `tfsdk:"sender_denylist"`
-	SenderDenyListPunycode    types.List    `tfsdk:"sender_denylist_punycode"`
-	SenderAllowList           types.List    `tfsdk:"sender_allowlist"`
-	SenderAllowListPunycode   types.List    `tfsdk:"sender_allowlist_punycode"`
-	RecipientDenyList         types.List    `tfsdk:"recipient_denylist"`
-	RecipientDenyListPunycode types.List    `tfsdk:"recipient_denylist_punycode"`
-	AutoRespondActive         types.Bool    `tfsdk:"auto_respond_active"`
-	AutoRespondSubject        types.String  `tfsdk:"auto_respond_subject"`
-	AutoRespondBody           types.String  `tfsdk:"auto_respond_body"`
-	AutoRespondExpiresOn      types.String  `tfsdk:"auto_respond_expires_on"`
-	FooterActive              types.Bool    `tfsdk:"footer_active"`
-	FooterPlainBody           types.String  `tfsdk:"footer_plain_body"`
-	FooterHtmlBody            types.String  `tfsdk:"footer_html_body"`
-	StorageUsage              types.Float64 `tfsdk:"storage_usage"`
-	Delegations               types.List    `tfsdk:"delegations"`
-	DelegationsPunycode       types.List    `tfsdk:"delegations_punycode"`
-	Identities                types.List    `tfsdk:"identities"`
-	IdentitiesPunycode        types.List    `tfsdk:"identities_punycode"`
+	LocalPart                 types.String `tfsdk:"local_part"`
+	DomainName                types.String `tfsdk:"domain_name"`
+	Address                   types.String `tfsdk:"address"`
+	Name                      types.String `tfsdk:"name"`
+	IsInternal                types.Bool   `tfsdk:"is_internal"`
+	MaySend                   types.Bool   `tfsdk:"may_send"`
+	MayReceive                types.Bool   `tfsdk:"may_receive"`
+	MayAccessImap             types.Bool   `tfsdk:"may_access_imap"`
+	MayAccessPop3             types.Bool   `tfsdk:"may_access_pop3"`
+	MayAccessManageSieve      types.Bool   `tfsdk:"may_access_manage_sieve"`
+	PasswordRecoveryEmail     types.String `tfsdk:"password_recovery_email"`
+	SpamAction                types.String `tfsdk:"spam_action"`
+	SpamAggressiveness        types.String `tfsdk:"spam_aggressiveness"`
+	Expirable                 types.Bool   `tfsdk:"expirable"`
+	ExpiresOn                 types.String `tfsdk:"expires_on"`
+	RemoveUponExpiry          types.Bool   `tfsdk:"remove_upon_expiry"`
+	SenderDenyList            types.List   `tfsdk:"sender_denylist"`
+	SenderDenyListPunycode    types.List   `tfsdk:"sender_denylist_punycode"`
+	SenderAllowList           types.List   `tfsdk:"sender_allowlist"`
+	SenderAllowListPunycode   types.List   `tfsdk:"sender_allowlist_punycode"`
+	RecipientDenyList         types.List   `tfsdk:"recipient_denylist"`
+	RecipientDenyListPunycode types.List   `tfsdk:"recipient_denylist_punycode"`
+	AutoRespondActive         types.Bool   `tfsdk:"auto_respond_active"`
+	AutoRespondSubject        types.String `tfsdk:"auto_respond_subject"`
+	AutoRespondBody           types.String `tfsdk:"auto_respond_body"`
+	AutoRespondExpiresOn      types.String `tfsdk:"auto_respond_expires_on"`
+	FooterActive              types.Bool   `tfsdk:"footer_active"`
+	FooterPlainBody           types.String `tfsdk:"footer_plain_body"`
+	FooterHtmlBody            types.String `tfsdk:"footer_html_body"`
+	Delegations               types.List   `tfsdk:"delegations"`
+	DelegationsPunycode       types.List   `tfsdk:"delegations_punycode"`
+	Identities                types.List   `tfsdk:"identities"`
+	IdentitiesPunycode        types.List   `tfsdk:"identities_punycode"`
 }
 
 func (d *mailboxesDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
@@ -251,11 +250,6 @@ func (d *mailboxesDataSource) Schema(_ context.Context, _ datasource.SchemaReque
 							MarkdownDescription: "The footer of this mailbox in text/html format.",
 							Computed:            true,
 						},
-						"storage_usage": schema.Float64Attribute{
-							Description:         "The current storage usage of this mailbox.",
-							MarkdownDescription: "The current storage usage of this mailbox.",
-							Computed:            true,
-						},
 						"delegations": schema.ListAttribute{
 							Description:         "The delegations of this mailbox in unicode.",
 							MarkdownDescription: "The delegations of this mailbox in unicode.",
@@ -373,7 +367,6 @@ func (d *mailboxesDataSource) Read(ctx context.Context, req datasource.ReadReque
 			FooterActive:              types.BoolValue(mailbox.FooterActive),
 			FooterPlainBody:           types.StringValue(mailbox.FooterPlainBody),
 			FooterHtmlBody:            types.StringValue(mailbox.FooterHtmlBody),
-			StorageUsage:              types.Float64Value(mailbox.StorageUsage),
 			Delegations:               delegations,
 			DelegationsPunycode:       delegationsPunycode,
 			Identities:                identities,


### PR DESCRIPTION
Fixes #26 

The attribute was removed from the Terraform resources/data-sources only and is still available in the migadu-client package in case someone wants to re-use the code outside of Terraform.