### PR TITLE
Remove identitites from mailbox models

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -68,7 +68,7 @@ jobs:
           terraform_wrapper: false
       - id: provider_tests
         name: Provider Tests
-        run: go test -v -cover -parallel=4 -timeout=900s -tags simulator ./internal/provider/...
+        run: go test -v -cover -parallel=4 -timeout=900s ./internal/provider/...
         env:
           TF_ACC: "1"
   terratest:
@@ -97,4 +97,4 @@ jobs:
         run: make install
       - id: terratest
         name: Run Terratest Tests
-        run: go test -parallel=4 -timeout=900s -tags simulator ./terratest/tests
+        run: go test -parallel=4 -timeout=900s ./terratest/tests

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,5 +3,3 @@
 
 run:
   timeout: 5m
-  build-tags:
-    - simulator

--- a/docs/data-sources/mailbox.md
+++ b/docs/data-sources/mailbox.md
@@ -47,7 +47,6 @@ data "migadu_mailbox" "idn" {
 - `footer_html_body` (String) The footer of the mailbox in `text/html` format.
 - `footer_plain_body` (String) The footer of the mailbox in `text/plain` format.
 - `id` (String) Contains the value `local_part@domain_name`.
-- `identities` (Set of String) The identities of the mailbox.
 - `is_internal` (Boolean) Whether the mailbox is internal only. An internal mailbox can only receive emails from Migadu servers.
 - `may_access_imap` (Boolean) Whether the mailbox is allowed to use IMAP.
 - `may_access_manage_sieve` (Boolean) Whether the mailbox is allowed to manage the mail sieve.

--- a/docs/data-sources/mailboxes.md
+++ b/docs/data-sources/mailboxes.md
@@ -52,7 +52,6 @@ Read-Only:
 - `footer_active` (Boolean) Whether the footer of this mailbox is active.
 - `footer_html_body` (String) The footer of this mailbox in text/html format.
 - `footer_plain_body` (String) The footer of this mailbox in text/plain format.
-- `identities` (Set of String) The identities of this mailbox.
 - `is_internal` (Boolean) Whether this mailbox is internal only. An internal mailbox can only receive emails from Migadu servers.
 - `local_part` (String) The local part of the mailbox.
 - `may_access_imap` (Boolean) Whether this mailbox is allowed to use IMAP.

--- a/docs/resources/mailbox.md
+++ b/docs/resources/mailbox.md
@@ -59,7 +59,6 @@ resource "migadu_mailbox" "idn" {
 - `footer_active` (Boolean) Whether the footer of this mailbox is active.
 - `footer_html_body` (String) The footer of this mailbox in text/html format.
 - `footer_plain_body` (String) The footer of this mailbox in text/plain format.
-- `identities` (Set of String) The identities of the mailbox.
 - `is_internal` (Boolean) Whether this mailbox is internal only. An internal mailbox can only receive emails from Migadu servers.
 - `may_access_imap` (Boolean) Whether this mailbox is allowed to use IMAP.
 - `may_access_manage_sieve` (Boolean) Whether this mailbox is allowed to manage the mail sieve.

--- a/internal/provider/custom_types/email_address_set_value.go
+++ b/internal/provider/custom_types/email_address_set_value.go
@@ -73,9 +73,7 @@ func (v EmailAddressSetValue) SetSemanticEquals(ctx context.Context, newValuable
 }
 
 func (v EmailAddressSetValue) contains(ctx context.Context, other attr.Value) bool {
-	otherEmail, ok := other.(EmailAddressValue)
-
-	if ok {
+	if otherEmail, ok := other.(EmailAddressValue); ok {
 		for _, elem := range v.Elements() {
 			if email, ok := elem.(EmailAddressValue); ok {
 				if equal, _ := email.StringSemanticEquals(ctx, otherEmail); equal {

--- a/internal/provider/mailbox_data_source.go
+++ b/internal/provider/mailbox_data_source.go
@@ -59,7 +59,6 @@ type MailboxDataSourceModel struct {
 	FooterPlainBody       types.String                      `tfsdk:"footer_plain_body"`
 	FooterHtmlBody        types.String                      `tfsdk:"footer_html_body"`
 	Delegations           custom_types.EmailAddressSetValue `tfsdk:"delegations"`
-	Identities            custom_types.EmailAddressSetValue `tfsdk:"identities"`
 }
 
 func (d *MailboxDataSource) Metadata(_ context.Context, request datasource.MetadataRequest, response *datasource.MetadataResponse) {
@@ -297,18 +296,6 @@ func (d *MailboxDataSource) Schema(_ context.Context, _ datasource.SchemaRequest
 					},
 				},
 			},
-			"identities": schema.SetAttribute{
-				Description:         "The identities of the mailbox.",
-				MarkdownDescription: "The identities of the mailbox.",
-				Required:            false,
-				Optional:            false,
-				Computed:            true,
-				CustomType: custom_types.EmailAddressSetType{
-					SetType: types.SetType{
-						ElemType: custom_types.EmailAddressType{},
-					},
-				},
-			},
 		},
 	}
 }
@@ -365,12 +352,6 @@ func (d *MailboxDataSource) Read(ctx context.Context, request datasource.ReadReq
 		return
 	}
 
-	identities, diags := custom_types.NewEmailAddressSetValueFrom(ctx, mailbox.Identities)
-	response.Diagnostics.Append(diags...)
-	if response.Diagnostics.HasError() {
-		return
-	}
-
 	data.ID = custom_types.NewEmailAddressValue(fmt.Sprintf("%s@%s", data.LocalPart.ValueString(), data.DomainName.ValueString()))
 	data.Address = custom_types.NewEmailAddressValue(mailbox.Address)
 	data.Name = types.StringValue(mailbox.Name)
@@ -397,7 +378,6 @@ func (d *MailboxDataSource) Read(ctx context.Context, request datasource.ReadReq
 	data.SenderAllowList = senderAllowList
 	data.RecipientDenyList = recipientDenyList
 	data.Delegations = delegations
-	data.Identities = identities
 
 	response.Diagnostics.Append(response.State.Set(ctx, &data)...)
 }

--- a/internal/provider/mailbox_resource_test.go
+++ b/internal/provider/mailbox_resource_test.go
@@ -387,24 +387,6 @@ func TestMailboxResource_Configuration_Success(t *testing.T) {
 				Delegations: []string{"other@example.com"},
 			},
 		},
-		{
-			testcase: "identities",
-			configuration: `
-				name        = "Some Name"
-				domain_name = "example.com"
-				local_part  = "test"
-				password    = "secret"
-				identities = ["other@example.com"]
-			`,
-			want: model.Mailbox{
-				Name:       "Some Name",
-				DomainName: "example.com",
-				LocalPart:  "test",
-				Address:    "test@example.com",
-				Password:   "secret",
-				Identities: []string{"other@example.com"},
-			},
-		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.testcase, func(t *testing.T) {
@@ -428,7 +410,6 @@ func TestMailboxResource_Configuration_Success(t *testing.T) {
 							resource.TestCheckResourceAttr("migadu_mailbox.test", "password", tt.want.Password),
 							resource.TestCheckResourceAttr("migadu_mailbox.test", "password_recovery_email", tt.want.PasswordRecoveryEmail),
 							resource.TestCheckResourceAttr("migadu_mailbox.test", "delegations.#", strconv.Itoa(len(tt.want.Delegations))),
-							resource.TestCheckResourceAttr("migadu_mailbox.test", "identities.#", strconv.Itoa(len(tt.want.Identities))),
 						),
 					},
 				},

--- a/internal/provider/mailboxes_data_source.go
+++ b/internal/provider/mailboxes_data_source.go
@@ -64,7 +64,6 @@ type MailboxModel struct {
 	FooterPlainBody       types.String                      `tfsdk:"footer_plain_body"`
 	FooterHtmlBody        types.String                      `tfsdk:"footer_html_body"`
 	Delegations           custom_types.EmailAddressSetValue `tfsdk:"delegations"`
-	Identities            custom_types.EmailAddressSetValue `tfsdk:"identities"`
 }
 
 func (d *MailboxesDataSource) Metadata(_ context.Context, request datasource.MetadataRequest, response *datasource.MetadataResponse) {
@@ -315,18 +314,6 @@ func (d *MailboxesDataSource) Schema(_ context.Context, _ datasource.SchemaReque
 								},
 							},
 						},
-						"identities": schema.SetAttribute{
-							Description:         "The identities of this mailbox.",
-							MarkdownDescription: "The identities of this mailbox.",
-							Required:            false,
-							Optional:            false,
-							Computed:            true,
-							CustomType: custom_types.EmailAddressSetType{
-								SetType: types.SetType{
-									ElemType: custom_types.EmailAddressType{},
-								},
-							},
-						},
 					},
 				},
 			},
@@ -387,12 +374,6 @@ func (d *MailboxesDataSource) Read(ctx context.Context, request datasource.ReadR
 			return
 		}
 
-		identities, diags := custom_types.NewEmailAddressSetValueFrom(ctx, mailbox.Identities)
-		response.Diagnostics.Append(diags...)
-		if response.Diagnostics.HasError() {
-			return
-		}
-
 		model := MailboxModel{
 			LocalPart:             types.StringValue(mailbox.LocalPart),
 			DomainName:            custom_types.NewDomainNameValue(mailbox.DomainName),
@@ -421,7 +402,6 @@ func (d *MailboxesDataSource) Read(ctx context.Context, request datasource.ReadR
 			FooterPlainBody:       types.StringValue(mailbox.FooterPlainBody),
 			FooterHtmlBody:        types.StringValue(mailbox.FooterHtmlBody),
 			Delegations:           delegations,
-			Identities:            identities,
 		}
 		data.Mailboxes = append(data.Mailboxes, model)
 	}

--- a/project.mk
+++ b/project.mk
@@ -8,7 +8,7 @@ VERSION       = 9999.99.99
 OS_ARCH       ?= linux_amd64
 XDG_DATA_HOME ?= ~/.local/share
 
-out/${PROVIDER}: $(shell find internal -type f -name '*.go' -and -not -name '*test.go') $(shell find migadu -type f -name '*.go' -and -not -name '*test.go')
+out/${PROVIDER}: $(shell find internal -type f -name '*.go' -and -not -name '*test.go')
 	mkdir --parents $(@D)
 	go build -o out/${PROVIDER}
 
@@ -31,17 +31,17 @@ out/terratest-lock-sentinel: out/install-sentinel
 
 out/terratests-run-sentinel: out/terratest-lock-sentinel $(shell find terratest -type f -name '*.go') $(shell find terratest -type f -name '*.tf')
 	mkdir --parents $(@D)
-	gotestsum --format=testname -- -timeout=120s -parallel=4 -tags=simulator ./terratest/tests
+	gotestsum --format=testname -- -timeout=120s -parallel=4 ./terratest/tests
 	touch $@
 
-out/tests-sentinel: $(shell find internal -type f -name '*.go') $(shell find migadu -type f -name '*.go')
+out/tests-sentinel: $(shell find internal -type f -name '*.go')
 	mkdir --parents $(@D)
-	gotestsum --format=testname -- -v -cover -timeout=120s -parallel=4 -tags=simulator ./internal/provider ./migadu/...
+	gotestsum --format=testname -- -v -cover -timeout=120s -parallel=4 ./internal/provider
 	touch $@
 
-out/coverage.out: $(shell find internal -type f -name '*.go') $(shell find migadu -type f -name '*.go')
+out/coverage.out: $(shell find internal -type f -name '*.go')
 	mkdir --parents $(@D)
-	gotestsum --format=testname -- -v -cover -coverprofile=out/coverage.out -timeout=120s -parallel=4 -tags=simulator ./internal/provider ./migadu/...
+	gotestsum --format=testname -- -v -cover -coverprofile=out/coverage.out -timeout=120s -parallel=4 ./internal/provider
 
 out/coverage.html: out/coverage.out
 	go tool cover -html=out/coverage.out -o out/coverage.html
@@ -73,14 +73,14 @@ terratests: out/terratests-run-sentinel ## run all terratest tests
 
 .PHONY: terratest
 terratest: out/terratest-lock-sentinel ## run specific terratest tests
-	go test -v -timeout=120s -parallel=4 -tags simulator -run $(filter-out $@,$(MAKECMDGOALS)) ./terratest/tests
+	go test -v -timeout=120s -parallel=4 -run $(filter-out $@,$(MAKECMDGOALS)) ./terratest/tests
 
 .PHONY: tests
 tests: out/tests-sentinel ## run the unit tests
 
 .PHONY: test
 test: ## run specific unit tests
-	go test -v -timeout=120s -tags simulator -run $(filter-out $@,$(MAKECMDGOALS)) ./internal/provider ./migadu/...
+	go test -v -timeout=120s -run $(filter-out $@,$(MAKECMDGOALS)) ./internal/provider
 
 .PHONY: coverage
 coverage: out/coverage.html ## generate coverage report

--- a/terratest/data-sources/migadu_mailbox/outputs.tf
+++ b/terratest/data-sources/migadu_mailbox/outputs.tf
@@ -25,10 +25,6 @@ output "delegations" {
   value = data.migadu_mailbox.mailbox.delegations
 }
 
-output "identities" {
-  value = data.migadu_mailbox.mailbox.identities
-}
-
 output "auto_respond_active" {
   value = data.migadu_mailbox.mailbox.auto_respond_active
 }

--- a/terratest/resources/migadu_mailbox/invitation/outputs.tf
+++ b/terratest/resources/migadu_mailbox/invitation/outputs.tf
@@ -25,10 +25,6 @@ output "delegations" {
   value = migadu_mailbox.mailbox.delegations
 }
 
-output "identities" {
-  value = migadu_mailbox.mailbox.identities
-}
-
 output "auto_respond_active" {
   value = migadu_mailbox.mailbox.auto_respond_active
 }

--- a/terratest/resources/migadu_mailbox/password/outputs.tf
+++ b/terratest/resources/migadu_mailbox/password/outputs.tf
@@ -25,10 +25,6 @@ output "delegations" {
   value = migadu_mailbox.mailbox.delegations
 }
 
-output "identities" {
-  value = migadu_mailbox.mailbox.identities
-}
-
 output "auto_respond_active" {
   value = migadu_mailbox.mailbox.auto_respond_active
 }


### PR DESCRIPTION
If you need to read/write identities use the separate data sources or resources for identities.

fixes #145 