### PR TITLE
conditionally validate identity password

### DIFF
--- a/docs/resources/identity.md
+++ b/docs/resources/identity.md
@@ -39,7 +39,7 @@ resource "migadu_identity" "mailbox" {
   domain_name  = "example.com"
   local_part   = "some-mailbox"
   identity     = "some-identity"
-  password_use = "mailbox" # use mailbox password
+  password_use = "mailbox" # use identity user and mailbox password
 }
 
 # application specific password
@@ -47,7 +47,7 @@ resource "migadu_identity" "custom" {
   domain_name  = "example.com"
   local_part   = "some-mailbox"
   identity     = "some-identity"
-  password_use = "custom" # use custom user/password
+  password_use = "custom" # use identity user/password
   password     = "Sup3r_s3cr3T"
 }
 ```
@@ -60,7 +60,6 @@ resource "migadu_identity" "custom" {
 - `domain_name` (String) The domain name of the mailbox/identity.
 - `identity` (String) The local part of the identity.
 - `local_part` (String) The local part of the mailbox that owns the identity.
-- `password` (String, Sensitive) The password of the identity.
 
 ### Optional
 
@@ -73,6 +72,7 @@ resource "migadu_identity" "custom" {
 - `may_receive` (Boolean) Whether the identity is allowed to receive emails.
 - `may_send` (Boolean) Whether the identity is allowed to send emails.
 - `name` (String) The name of the identity.
+- `password` (String, Sensitive) The password of the identity.
 - `password_use` (String) Configures the password use of the identity. Use `none` if you just need to be able to send using a specific `From` identity, but still authenticate with the mailbox address and password. Use `mailbox` if you want an alternative address but linked to the same mailbox using the same password. Use `custom` if you need an application specific password (e.g. your phone), shared mailbox with individual passwords or sandboxing of accounts for specific services.
 
 ### Read-Only

--- a/examples/resources/migadu_identity/resource.tf
+++ b/examples/resources/migadu_identity/resource.tf
@@ -24,7 +24,7 @@ resource "migadu_identity" "mailbox" {
   domain_name  = "example.com"
   local_part   = "some-mailbox"
   identity     = "some-identity"
-  password_use = "mailbox" # use mailbox password
+  password_use = "mailbox" # use identity user and mailbox password
 }
 
 # application specific password
@@ -32,6 +32,6 @@ resource "migadu_identity" "custom" {
   domain_name  = "example.com"
   local_part   = "some-mailbox"
   identity     = "some-identity"
-  password_use = "custom" # use custom user/password
+  password_use = "custom" # use identity user/password
   password     = "Sup3r_s3cr3T"
 }

--- a/terratest/resources/migadu_identity/custom/main.tf
+++ b/terratest/resources/migadu_identity/custom/main.tf
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: The terraform-provider-migadu Authors
+# SPDX-License-Identifier: 0BSD
+
+terraform {
+  required_providers {
+    migadu = {
+      source  = "localhost/metio/migadu"
+      version = "9999.99.99"
+    }
+  }
+}
+
+provider "migadu" {
+  username = "terratest"
+  token    = "secret-token:foobar" // RFC 8959
+  endpoint = var.endpoint
+}

--- a/terratest/resources/migadu_identity/custom/outputs.tf
+++ b/terratest/resources/migadu_identity/custom/outputs.tf
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: The terraform-provider-migadu Authors
+# SPDX-License-Identifier: 0BSD
+
+output "id" {
+  value = migadu_identity.identity.id
+}
+
+output "domain_name" {
+  value = migadu_identity.identity.domain_name
+}
+
+output "local_part" {
+  value = migadu_identity.identity.local_part
+}
+
+output "address" {
+  value = migadu_identity.identity.address
+}
+
+output "name" {
+  value = migadu_identity.identity.name
+}

--- a/terratest/resources/migadu_identity/custom/resource.tf
+++ b/terratest/resources/migadu_identity/custom/resource.tf
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: The terraform-provider-migadu Authors
+# SPDX-License-Identifier: 0BSD
+
+resource "migadu_identity" "identity" {
+  name         = "Some Name"
+  domain_name  = var.domain_name
+  local_part   = var.local_part
+  identity     = var.identity
+  password_use = "custom"
+  password     = "secret-token:foobar" // RFC 8959
+}

--- a/terratest/resources/migadu_identity/custom/variables.tf
+++ b/terratest/resources/migadu_identity/custom/variables.tf
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: The terraform-provider-migadu Authors
+# SPDX-License-Identifier: 0BSD
+
+variable "endpoint" {
+  type = string
+}
+
+variable "domain_name" {
+  type = string
+}
+
+variable "local_part" {
+  type = string
+}
+
+variable "identity" {
+  type = string
+}

--- a/terratest/resources/migadu_identity/mailbox/main.tf
+++ b/terratest/resources/migadu_identity/mailbox/main.tf
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: The terraform-provider-migadu Authors
+# SPDX-License-Identifier: 0BSD
+
+terraform {
+  required_providers {
+    migadu = {
+      source  = "localhost/metio/migadu"
+      version = "9999.99.99"
+    }
+  }
+}
+
+provider "migadu" {
+  username = "terratest"
+  token    = "secret-token:foobar" // RFC 8959
+  endpoint = var.endpoint
+}

--- a/terratest/resources/migadu_identity/mailbox/outputs.tf
+++ b/terratest/resources/migadu_identity/mailbox/outputs.tf
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: The terraform-provider-migadu Authors
+# SPDX-License-Identifier: 0BSD
+
+output "id" {
+  value = migadu_identity.identity.id
+}
+
+output "domain_name" {
+  value = migadu_identity.identity.domain_name
+}
+
+output "local_part" {
+  value = migadu_identity.identity.local_part
+}
+
+output "address" {
+  value = migadu_identity.identity.address
+}
+
+output "name" {
+  value = migadu_identity.identity.name
+}

--- a/terratest/resources/migadu_identity/mailbox/resource.tf
+++ b/terratest/resources/migadu_identity/mailbox/resource.tf
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: The terraform-provider-migadu Authors
+# SPDX-License-Identifier: 0BSD
+
+resource "migadu_identity" "identity" {
+  name         = "Some Name"
+  domain_name  = var.domain_name
+  local_part   = var.local_part
+  identity     = var.identity
+  password_use = "mailbox"
+}

--- a/terratest/resources/migadu_identity/mailbox/variables.tf
+++ b/terratest/resources/migadu_identity/mailbox/variables.tf
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: The terraform-provider-migadu Authors
+# SPDX-License-Identifier: 0BSD
+
+variable "endpoint" {
+  type = string
+}
+
+variable "domain_name" {
+  type = string
+}
+
+variable "local_part" {
+  type = string
+}
+
+variable "identity" {
+  type = string
+}

--- a/terratest/resources/migadu_identity/none/main.tf
+++ b/terratest/resources/migadu_identity/none/main.tf
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: The terraform-provider-migadu Authors
+# SPDX-License-Identifier: 0BSD
+
+terraform {
+  required_providers {
+    migadu = {
+      source  = "localhost/metio/migadu"
+      version = "9999.99.99"
+    }
+  }
+}
+
+provider "migadu" {
+  username = "terratest"
+  token    = "secret-token:foobar" // RFC 8959
+  endpoint = var.endpoint
+}

--- a/terratest/resources/migadu_identity/none/outputs.tf
+++ b/terratest/resources/migadu_identity/none/outputs.tf
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: The terraform-provider-migadu Authors
+# SPDX-License-Identifier: 0BSD
+
+output "id" {
+  value = migadu_identity.identity.id
+}
+
+output "domain_name" {
+  value = migadu_identity.identity.domain_name
+}
+
+output "local_part" {
+  value = migadu_identity.identity.local_part
+}
+
+output "address" {
+  value = migadu_identity.identity.address
+}
+
+output "name" {
+  value = migadu_identity.identity.name
+}

--- a/terratest/resources/migadu_identity/none/resource.tf
+++ b/terratest/resources/migadu_identity/none/resource.tf
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: The terraform-provider-migadu Authors
+# SPDX-License-Identifier: 0BSD
+
+resource "migadu_identity" "identity" {
+  name         = "Some Name"
+  domain_name  = var.domain_name
+  local_part   = var.local_part
+  identity     = var.identity
+  password_use = "none"
+}

--- a/terratest/resources/migadu_identity/none/variables.tf
+++ b/terratest/resources/migadu_identity/none/variables.tf
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: The terraform-provider-migadu Authors
+# SPDX-License-Identifier: 0BSD
+
+variable "endpoint" {
+  type = string
+}
+
+variable "domain_name" {
+  type = string
+}
+
+variable "local_part" {
+  type = string
+}
+
+variable "identity" {
+  type = string
+}

--- a/terratest/tests/identity_resource_test.go
+++ b/terratest/tests/identity_resource_test.go
@@ -1,0 +1,92 @@
+/*
+ * SPDX-FileCopyrightText: The terraform-provider-migadu Authors
+ * SPDX-License-Identifier: 0BSD
+ */
+
+package acceptance_test
+
+import (
+	"fmt"
+	"github.com/gruntwork-io/terratest/modules/terraform"
+	"github.com/metio/migadu-client.go/model"
+	"github.com/metio/migadu-client.go/simulator"
+	"github.com/stretchr/testify/assert"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestIdentityResource(t *testing.T) {
+	testCases := map[string]struct {
+		domain    string
+		localPart string
+		identity  string
+		state     []model.Identity
+		want      model.Identity
+	}{
+		"single": {
+			domain:    "example.com",
+			localPart: "some",
+			identity:  "other",
+			state:     []model.Identity{},
+			want: model.Identity{
+				LocalPart:  "some",
+				DomainName: "example.com",
+				Address:    "other@example.com",
+			},
+		},
+		"multiple": {
+			domain:    "example.com",
+			localPart: "some",
+			identity:  "other",
+			state: []model.Identity{
+				{
+					LocalPart:  "different",
+					DomainName: "example.com",
+					Address:    "other@example.com",
+				},
+			},
+			want: model.Identity{
+				LocalPart:  "some",
+				DomainName: "example.com",
+				Address:    "other@example.com",
+			},
+		},
+		"idna": {
+			domain:    "hoß.de",
+			localPart: "test",
+			identity:  "other",
+			state:     []model.Identity{},
+			want: model.Identity{
+				LocalPart:  "test",
+				DomainName: "xn--ho-hia.de",
+				Address:    "other@xn--ho-hia.de",
+			},
+		},
+	}
+	for name, testCase := range testCases {
+		for _, passwordUse := range []string{"custom", "mailbox", "none"} {
+			t.Run(fmt.Sprintf("%s/%s", passwordUse, name), func(t *testing.T) {
+				server := httptest.NewServer(simulator.MigaduAPI(t, &simulator.State{Identities: testCase.state}))
+				defer server.Close()
+
+				terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
+					TerraformDir: fmt.Sprintf("../resources/migadu_identity/%s", passwordUse),
+					Vars: map[string]interface{}{
+						"endpoint":    server.URL,
+						"domain_name": testCase.domain,
+						"local_part":  testCase.localPart,
+						"identity":    testCase.identity,
+					},
+				})
+
+				defer terraform.Destroy(t, terraformOptions)
+				terraform.InitAndApplyAndIdempotent(t, terraformOptions)
+
+				assert.Equal(t, fmt.Sprintf("%s@%s/%s", testCase.localPart, testCase.domain, testCase.identity), terraform.Output(t, terraformOptions, "id"), "id")
+				assert.Equal(t, testCase.domain, terraform.Output(t, terraformOptions, "domain_name"), "domain_name")
+				assert.Equal(t, testCase.localPart, terraform.Output(t, terraformOptions, "local_part"), "local_part")
+				assert.Equal(t, testCase.want.Address, terraform.Output(t, terraformOptions, "address"), "address")
+			})
+		}
+	}
+}

--- a/terratest/tests/mailbox_resource_test.go
+++ b/terratest/tests/mailbox_resource_test.go
@@ -164,30 +164,30 @@ func TestMailboxResource_Using_RecoveryEmail(t *testing.T) {
 			},
 		},
 	}
-	for name, tt := range testCases {
+	for name, testCase := range testCases {
 		t.Run(name, func(t *testing.T) {
-			server := httptest.NewServer(simulator.MigaduAPI(t, &simulator.State{Mailboxes: tt.state}))
+			server := httptest.NewServer(simulator.MigaduAPI(t, &simulator.State{Mailboxes: testCase.state}))
 			defer server.Close()
 
 			terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
 				TerraformDir: "../resources/migadu_mailbox/invitation",
 				Vars: map[string]interface{}{
 					"endpoint":    server.URL,
-					"domain_name": tt.domain,
-					"local_part":  tt.localPart,
+					"domain_name": testCase.domain,
+					"local_part":  testCase.localPart,
 				},
 			})
 
 			defer terraform.Destroy(t, terraformOptions)
 			terraform.InitAndApplyAndIdempotent(t, terraformOptions)
 
-			assert.Equal(t, fmt.Sprintf("%s@%s", tt.localPart, tt.domain), terraform.Output(t, terraformOptions, "id"), "id")
-			assert.Equal(t, tt.domain, terraform.Output(t, terraformOptions, "domain_name"), "domain_name")
-			assert.Equal(t, tt.localPart, terraform.Output(t, terraformOptions, "local_part"), "local_part")
-			assert.Equal(t, tt.want.Address, terraform.Output(t, terraformOptions, "address"), "address")
-			assert.Equal(t, tt.want.PasswordRecoveryEmail, terraform.Output(t, terraformOptions, "password_recovery_email"), "password_recovery_email")
-			assert.Equal(t, tt.want.ExpiresOn, terraform.Output(t, terraformOptions, "expires_on"), "expires_on")
-			assert.Equal(t, strconv.FormatBool(tt.want.Expirable), terraform.Output(t, terraformOptions, "expirable"), "expirable")
+			assert.Equal(t, fmt.Sprintf("%s@%s", testCase.localPart, testCase.domain), terraform.Output(t, terraformOptions, "id"), "id")
+			assert.Equal(t, testCase.domain, terraform.Output(t, terraformOptions, "domain_name"), "domain_name")
+			assert.Equal(t, testCase.localPart, terraform.Output(t, terraformOptions, "local_part"), "local_part")
+			assert.Equal(t, testCase.want.Address, terraform.Output(t, terraformOptions, "address"), "address")
+			assert.Equal(t, testCase.want.PasswordRecoveryEmail, terraform.Output(t, terraformOptions, "password_recovery_email"), "password_recovery_email")
+			assert.Equal(t, testCase.want.ExpiresOn, terraform.Output(t, terraformOptions, "expires_on"), "expires_on")
+			assert.Equal(t, strconv.FormatBool(testCase.want.Expirable), terraform.Output(t, terraformOptions, "expirable"), "expirable")
 		})
 	}
 }


### PR DESCRIPTION
An identity password is only required if password_use is set to 'custom'. All other values for password_use will tell the Migadu API to ignore the password. We are a bit stricter here and enforce that no password is set if password_use is not set to 'custom'.

Relates to #145