### PR TITLE
add custom validator for password_use

### DIFF
--- a/internal/provider/custom_validators/identity_password_use_validator.go
+++ b/internal/provider/custom_validators/identity_password_use_validator.go
@@ -1,0 +1,46 @@
+/*
+ * SPDX-FileCopyrightText: The terraform-provider-migadu Authors
+ * SPDX-License-Identifier: 0BSD
+ */
+
+package custom_validators
+
+import (
+	"context"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+)
+
+var _ validator.String = passwordUseValidator{}
+
+type passwordUseValidator struct{}
+
+func (v passwordUseValidator) Description(ctx context.Context) string {
+	return v.MarkdownDescription(ctx)
+}
+
+func (v passwordUseValidator) MarkdownDescription(_ context.Context) string {
+	return "password_use attribute is invalid"
+}
+
+func (v passwordUseValidator) ValidateString(ctx context.Context, request validator.StringRequest, response *validator.StringResponse) {
+	if request.ConfigValue.IsNull() || request.ConfigValue.IsUnknown() {
+		return
+	}
+
+	value := request.ConfigValue
+
+	stringvalidator.OneOf("none", "mailbox", "custom").ValidateString(ctx, request, response)
+
+	if value.ValueString() == "none" || value.ValueString() == "mailbox" {
+		stringvalidator.ConflictsWith(path.MatchRoot("password")).ValidateString(ctx, request, response)
+	} else if value.ValueString() == "custom" {
+		stringvalidator.AlsoRequires(path.MatchRoot("password")).ValidateString(ctx, request, response)
+	}
+}
+
+// PasswordUse validates the `password_use` attribute of an identity resource
+func PasswordUse() validator.String {
+	return passwordUseValidator{}
+}

--- a/internal/provider/identity_resource.go
+++ b/internal/provider/identity_resource.go
@@ -22,6 +22,7 @@ import (
 	"github.com/metio/migadu-client.go/client"
 	"github.com/metio/migadu-client.go/model"
 	"github.com/metio/terraform-provider-migadu/internal/provider/custom_types"
+	"github.com/metio/terraform-provider-migadu/internal/provider/custom_validators"
 	"net/http"
 	"strings"
 )
@@ -193,14 +194,7 @@ func (r *IdentityResource) Schema(_ context.Context, _ resource.SchemaRequest, r
 				Computed:            true,
 				Default:             stringdefault.StaticString("none"),
 				Validators: []validator.String{
-					stringvalidator.Any(
-						stringvalidator.All(
-							stringvalidator.OneOf("none", "mailbox"),
-							stringvalidator.ConflictsWith(path.MatchRoot("password"))),
-						stringvalidator.All(
-							stringvalidator.OneOf("custom"),
-							stringvalidator.AlsoRequires(path.MatchRoot("password"))),
-					),
+					custom_validators.PasswordUse(),
 				},
 			},
 			"footer_active": schema.BoolAttribute{

--- a/internal/provider/identity_resource_test.go
+++ b/internal/provider/identity_resource_test.go
@@ -559,7 +559,7 @@ func TestIdentityResource_Configuration_Errors(t *testing.T) {
 				password     = "secret"
 				password_use = "invalid"
 			`,
-			error: `Attribute password_use value must be one of: \["none" "mailbox"\]`,
+			error: `Attribute password_use value must be one of: \["none" "mailbox" "custom"\]`,
 		},
 		{
 			name: "no-custom-password",


### PR DESCRIPTION
This custom validator relies on the built-in validators but produces at most one validation message which should be less confusing for users.

fixes #152