### PR TITLE
Fix `migadu_identity` import `password_use`/`password` as null in state

### DIFF
--- a/internal/provider/identity_resource.go
+++ b/internal/provider/identity_resource.go
@@ -311,6 +311,10 @@ func (r *IdentityResource) Read(ctx context.Context, request resource.ReadReques
 	state.MayAccessImap = types.BoolValue(identity.MayAccessImap)
 	state.MayAccessPop3 = types.BoolValue(identity.MayAccessPop3)
 	state.MayAccessManageSieve = types.BoolValue(identity.MayAccessManageSieve)
+	state.PasswordUse = types.StringValue(identity.PasswordUse)
+	if state.Password.IsUnknown() {
+		state.Password = types.StringNull()
+	}
 	state.FooterActive = types.BoolValue(identity.FooterActive)
 	state.FooterPlainBody = types.StringValue(identity.FooterPlainBody)
 	state.FooterHtmlBody = types.StringValue(identity.FooterHtmlBody)
@@ -357,6 +361,7 @@ func (r *IdentityResource) Update(ctx context.Context, request resource.UpdateRe
 	plan.MayAccessImap = types.BoolValue(updatedIdentity.MayAccessImap)
 	plan.MayAccessPop3 = types.BoolValue(updatedIdentity.MayAccessPop3)
 	plan.MayAccessManageSieve = types.BoolValue(updatedIdentity.MayAccessManageSieve)
+	plan.PasswordUse = types.StringValue(updatedIdentity.PasswordUse)
 	plan.FooterActive = types.BoolValue(updatedIdentity.FooterActive)
 	plan.FooterPlainBody = types.StringValue(updatedIdentity.FooterPlainBody)
 	plan.FooterHtmlBody = types.StringValue(updatedIdentity.FooterHtmlBody)

--- a/internal/provider/identity_resource_test.go
+++ b/internal/provider/identity_resource_test.go
@@ -110,8 +110,7 @@ func TestIdentityResource_API_Success_With_Password(t *testing.T) {
 						ImportState:       true,
 						ImportStateVerify: true,
 						ImportStateVerifyIgnore: []string{
-							"password",     // Migadu API does not allow reading passwords
-							"password_use", // Migadu API does not allow reading passwords
+							"password", // Migadu API does not allow reading passwords
 						},
 					},
 					{
@@ -273,9 +272,6 @@ func TestIdentityResource_API_Success_Without_Password(t *testing.T) {
 						ResourceName:      "migadu_identity.test",
 						ImportState:       true,
 						ImportStateVerify: true,
-						ImportStateVerifyIgnore: []string{
-							"password_use", // Migadu API does not allow reading passwords
-						},
 					},
 					{
 						Config: providerConfig(server.URL) + fmt.Sprintf(`
@@ -389,9 +385,6 @@ func TestIdentityResource_API_Success_With_Default_PasswordUse(t *testing.T) {
 						ResourceName:      "migadu_identity.test",
 						ImportState:       true,
 						ImportStateVerify: true,
-						ImportStateVerifyIgnore: []string{
-							"password_use", // Migadu API does not allow reading passwords
-						},
 					},
 					{
 						Config: providerConfig(server.URL) + fmt.Sprintf(`


### PR DESCRIPTION
Importing a `migadu_identity` resource leaves a dirty plan with spurious additions for `password_use`, `password`, and as a cascading effect, `footer_html_body` and `footer_plain_body`:

```tf
+ footer_html_body        = (known after apply)
+ footer_plain_body       = (known after apply)
+ password                = (sensitive value)
+ password_use            = "none"
```

Because these are `+` additions (null -> value) rather than `~` updates, `lifecycle { ignore_changes = [...] }` can't suppress them.

### Cause

`Read` never sets `state.PasswordUse` from the API response. `ImportState` only populates `local_part`, `domain_name`, and `identity`, so `password_use` is null in state after import. On the next plan, the schema default `stringdefault.StaticString("none")` produces a null -> `"none"` diff, which schedules an update.

That update then marks all `Computed` fields as unknown, which is why `footer_html_body` and `footer_plain_body` show up as `(known after apply)`, they're not a separate bug.

`password` was also missing the same `IsUnknown` guard that `mailbox_resource.go` already has.

`migadu_mailbox` with similar `password` fields in the API isn't affected because its `Read` already handles `password` correctly (https://github.com/metio/terraform-provider-migadu/pull/80)

https://github.com/metio/terraform-provider-migadu/blob/fd5ae7b5572220e0dab9ca460f613fc03b86bbd9/internal/provider/mailbox_resource.go#L582-L584