### PR TITLE
Fix inconsistent result after apply when creating rewrite rules

### DIFF
--- a/internal/provider/rewrite_rule_resource.go
+++ b/internal/provider/rewrite_rule_resource.go
@@ -181,6 +181,26 @@ func (r *RewriteRuleResource) Create(ctx context.Context, request resource.Creat
 		return
 	}
 
+	// The Migadu API ignores order_num on create and always appends new
+	// rules, but honors order_num on update. Apply an explicitly
+	// configured order with a follow-up update. Track the created rule
+	// in state first so it is not orphaned if the update fails.
+	if !plan.OrderNum.IsUnknown() && plan.OrderNum.ValueInt64() != createdRewrite.OrderNum {
+		requestedOrderNum := plan.OrderNum.ValueInt64()
+		plan.ID = types.StringValue(CreateRewriteRuleID(plan.DomainName, plan.Name))
+		plan.Name = types.StringValue(createdRewrite.Name)
+		plan.LocalPartRule = types.StringValue(createdRewrite.LocalPartRule)
+		plan.OrderNum = types.Int64Value(createdRewrite.OrderNum)
+		response.Diagnostics.Append(response.State.Set(ctx, plan)...)
+
+		rewrite.OrderNum = requestedOrderNum
+		createdRewrite, err = r.MigaduClient.UpdateRewriteRule(ctx, plan.DomainName.ValueString(), createdRewrite.Name, rewrite)
+		if err != nil {
+			response.Diagnostics.Append(RewriteRuleCreateError(err))
+			return
+		}
+	}
+
 	plan.ID = types.StringValue(CreateRewriteRuleID(plan.DomainName, plan.Name))
 	plan.Name = types.StringValue(createdRewrite.Name)
 	plan.LocalPartRule = types.StringValue(createdRewrite.LocalPartRule)

--- a/internal/provider/rewrite_rule_resource.go
+++ b/internal/provider/rewrite_rule_resource.go
@@ -15,7 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -113,9 +113,11 @@ func (r *RewriteRuleResource) Schema(_ context.Context, _ resource.SchemaRequest
 				Required:            false,
 				Optional:            true,
 				Computed:            true,
-				Default:             int64default.StaticInt64(0),
 				Validators: []validator.Int64{
 					int64validator.AtLeast(0),
+				},
+				PlanModifiers: []planmodifier.Int64{
+					int64planmodifier.UseStateForUnknown(),
 				},
 			},
 			"destinations": schema.SetAttribute{


### PR DESCRIPTION
Fixes #189

The `order_num` attribute had a static default of 0, but the Migadu API ignores `order_num` on create and always assigns the next sequential number. Every create therefore failed Terraform's consistency check and left the resource tainted, so the following apply planned a replace whose create failed with a duplicate-name 400. More details in [my comment on #189](https://github.com/metio/terraform-provider-migadu/issues/189#issuecomment-4962004475).

Two commits:

1. Drop the static default and use `UseStateForUnknown` instead, so the planned value is unknown on create and the server-assigned number passes the consistency check.
2. Since the API now honors `order_num` on update (verified against the live API in July 2026), apply an explicitly configured `order_num` with a follow-up update after create. The created rule is written to state before that update so it is not orphaned if the update fails.

The existing unit tests pass unchanged. One caveat: the simulator echoes `order_num` back on create rather than modeling the server's append behavior, so the follow-up update path is not exercised by the unit tests; I verified it against the live API instead. If you'd rather take just the schema fix, I'm happy to drop the second commit.
